### PR TITLE
feat: 支持自定义日志默认展开类别

### DIFF
--- a/src/SocketLog.php
+++ b/src/SocketLog.php
@@ -33,6 +33,8 @@ class SocketLog implements LogHandlerInterface
         'force_client_ids'    => [],
         // 限制允许读取日志的client_id
         'allow_client_ids'    => [],
+        //输出到浏览器默认展开的日志级别
+        'expand_level'        => ['debug'],
     ];
 
     protected $css = [
@@ -98,7 +100,7 @@ class SocketLog implements LogHandlerInterface
 
         foreach ($log as $type => $val) {
             $trace[] = [
-                'type' => 'groupCollapsed',
+                'type' => in_array($type, $this->config['expand_level']) ? 'group' : 'groupCollapsed',
                 'msg'  => '[ ' . $type . ' ]',
                 'css'  => $this->css[$type] ?? '',
             ];


### PR DESCRIPTION
同步 TP 5.1 SocketLog 驱动改进：https://github.com/top-think/framework/pull/1411

#### 支持自定义`默认展开日志类别`
- 默认`debug`级别信息在浏览器 console 输出时自动展开
- 通过配置`expand_level `选项自定义默认展开类别。方便调试。